### PR TITLE
Refactoring for Usability

### DIFF
--- a/scope/Program.cs
+++ b/scope/Program.cs
@@ -85,7 +85,7 @@ namespace DGScope
                     //Either take a filepath as a parameter with the file argument, or accept it as a sole argument.  If neither is a valid file path, leave as null to be handled upon Start()
 
                     //Argument format: "--f=PATH" or "--file=PATH" (quotes need not be included if running via the command line, but must be included if passed as arguments via Visual Studio's Debug Config)
-                    if (arg.Contains("--f") || arg.Contains("--file"))
+                    if (arg.StartsWith("--f") || arg.StartsWith("--file"))
                     {
                         string paramFileName = arg.Split('=')[1].Trim();
                         if (File.Exists(paramFileName))
@@ -99,8 +99,8 @@ namespace DGScope
 
                     //Screensaver commands:
 
-                    //Start screensaver in foreground mode
-                    if (arg.Contains("--c") || arg.Contains("--screensaver_foreground") || arg.Contains("/c"))
+                    //Start in config mode
+                    if (arg.StartsWith("--c") || arg.StartsWith("--config") || arg.StartsWith("/c"))
                     {
                         if(facilityConfig == null)
                         {
@@ -121,12 +121,12 @@ namespace DGScope
                         inhibit = true;
                     }
                     //Start screensaver in normal mode
-                    else if (arg.Contains("--s") || arg.Contains("--screensaver") || arg.Contains("/c"))
+                    else if (arg.StartsWith("--s") || arg.StartsWith("--screensaver") || arg.StartsWith("/c"))
                     {
                         screensaver = true;
                     }
                     //Start screensaver in child mode
-                    else if (arg.Contains("--p") || arg.Contains("--screensaver_child") || arg.Contains("/c"))
+                    else if (arg.StartsWith("--p") || arg.StartsWith("--screensaver_child") || arg.StartsWith("/p"))
                     {
                         inhibit = true;
                     }

--- a/scope/Program.cs
+++ b/scope/Program.cs
@@ -22,7 +22,7 @@ namespace DGScope
                 {
                     open.Filter = "Facility Config File (*.xml)|*.xml|All files (*.*)|*.*";
                     open.FilterIndex = 1;
-                    open.CheckFileExists = false;
+                    open.CheckFileExists = true;
                     if (open.ShowDialog() == DialogResult.OK)
                     {
                         facilityConfig = open.FileName;
@@ -31,7 +31,30 @@ namespace DGScope
                     {
                         var mboxresult = MessageBox.Show("Would you like to create a new config file?","No Config File Selected", MessageBoxButtons.YesNo, MessageBoxIcon.Error);
                         if (mboxresult == DialogResult.Yes)
-                            Start(false, "");
+                        {
+                            using (SaveFileDialog save = new SaveFileDialog())
+                            {
+                                save.Filter = "Facility Config File (*.xml)|*.xml|All files (*.*)|*.*";
+                                save.FilterIndex = 1;
+                                save.CheckFileExists = false;
+                                if (save.ShowDialog() == DialogResult.OK)
+                                {
+                                    var newfile = save.FileName;
+                                    try
+                                    {
+                                        using (_ = File.Create(newfile))
+                                        facilityConfig = newfile;
+                                        File.Delete(newfile);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        MessageBox.Show(ex.Message);
+                                    }
+                                    if (facilityConfig != null)
+                                        Start(false, facilityConfig);
+                                }
+                            }
+                        }
                         else
                             Environment.Exit(0);
                     }

--- a/scope/Program.cs
+++ b/scope/Program.cs
@@ -74,7 +74,10 @@ namespace DGScope
             {
                 foreach (var arg in args)
                 {
-                    if (arg.Contains("--c") || arg.Contains("--clean"))
+                    //Screensaver commands:
+                    
+                    //Start screensaver in foreground mode
+                    if (arg.Contains("--c") || arg.Contains("--screensaver_foreground") || arg.Contains("/C"))
                     {
                         facilityConfig = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "DGScope.xml");
                         RadarWindow radarWindow;
@@ -91,26 +94,27 @@ namespace DGScope
                         radarWindow.SaveSettings(facilityConfig);
                         inhibit = true;
                     }
-                    if (arg.Contains("--s") || arg.Contains("--screensaver") || arg.Contains("/S"))
+                    //Start screensaver in normal mode
+                    else if (arg.Contains("--s") || arg.Contains("--screensaver") || arg.Contains("/S"))
                     {
                         screensaver = true;
                     }
-                    //I honestly don't know what this command does
-                    else if (arg.Contains("--p") || arg.Contains("--p_command_name"))
+                    //Start screensaver in child mode
+                    else if (arg.Contains("--p") || arg.Contains("--screensaver_child") || arg.Contains("/P"))
                     {
                         inhibit = true;
-                    }/*
-                     //This is what I mean by "f u, eat my file", but I'll leave it here in case you want to keep it
-                    else
-                    {
-                        facilityConfig = arg;
-                    }*/
-
-                    //Passing a file as an argument a slightly more official way than "f u, eat my file"
+                    }
+                    
+                    //Selecting which facility config file to use:
+                    
                     //Argument format: "--f=PATH" or "--file=PATH" (quotes need not be included if running via the command line, but must be included if passed as arguments via Visual Studio's Debug Config)
                     if (arg.Contains("--f") || arg.Contains("--file"))
                     {
                         facilityConfig = arg.Split('=')[1].Trim();
+                    }
+                    else
+                    {
+                        facilityConfig = arg;
                     }
                     
                 }

--- a/scope/Program.cs
+++ b/scope/Program.cs
@@ -91,8 +91,8 @@ namespace DGScope
             {
                 gitVersion = reader.ReadToEnd();
             }
-            Console.WriteLine(gitVersion);
             */
+            Console.WriteLine(gitVersion);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             LoadReceiverPlugins();

--- a/scope/Program.cs
+++ b/scope/Program.cs
@@ -91,7 +91,7 @@ namespace DGScope
                         radarWindow.SaveSettings(facilityConfig);
                         inhibit = true;
                     }
-                    if (arg.Contains("--s") || arg.Contains("--screensaver"))
+                    if (arg.Contains("--s") || arg.Contains("--screensaver") || arg.Contains("/S"))
                     {
                         screensaver = true;
                     }

--- a/scope/Program.cs
+++ b/scope/Program.cs
@@ -84,7 +84,7 @@ namespace DGScope
             string gitVersion = string.Empty;
             using (Stream stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("DGScope.version.txt"))
             //Don't get mad at me... This is the only way I could get it to stop throwing a "not found" error on the version file... Even though the version file exists
-            gitVersion = stream == null ? "1.0.0" : new StreamReader(stream).ReadToEnd();
+            gitVersion = stream == null ? "No git version description" : new StreamReader(stream).ReadToEnd();
             /*
             //Here's your old code in case you decide to delete mine above
             using (StreamReader reader = new StreamReader(stream))


### PR DESCRIPTION
settingsPath is now facilityConfig to make way for a future clientConfig XML to universalize the facility config files.

CLI arguments now follow standard CLI convention (as defined by http://docopt.org/)

Added a default to ver. 1.0.0 if no version is found... This is mostly a hack to make things run correctly locally, but could apply to future version checking

This is the last mega-commit I will submit, I promise. 